### PR TITLE
Im Frontend soll auch </HEAD> oder </BoDy> funktionieren

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -83,7 +83,7 @@ if (rex::isFrontend()) {
         $minibar = rex_minibar::getInstance()->get();
 
         if ($minibar) {
-            $ep->setSubject(str_replace(
+            $ep->setSubject(str_ireplace(
                     ['</head>', '</body>'],
                     ['<link rel="stylesheet" type="text/css" href="' . $addon->getAssetsUrl('styles.css') .'" /></head>', $minibar . '</body>'],
                     $ep->getSubject())


### PR DESCRIPTION
da html nicht case-sensitive ist.

für die Ersetzungen von backend html ist dies so nicht nötig, da wir dort wissen dass es immer `<section>` heißt

Ungetestet