### PR TITLE
Lazy element wirft 404 bei aktuellem YRewrite

### DIFF
--- a/lib/api_minibar.php
+++ b/lib/api_minibar.php
@@ -28,7 +28,7 @@ class rex_api_minibar extends rex_api_function
                 $fragment = new rex_fragment([
                     'element' => $element,
                 ]);
-                rex_response::setStatus(rex_response::HTTP_OK); 
+                rex_response::setStatus(rex_response::HTTP_OK);
                 rex_response::sendContent($fragment->parse('core/minibar/minibar_element.php'));
                 exit();
             }

--- a/lib/api_minibar.php
+++ b/lib/api_minibar.php
@@ -28,7 +28,7 @@ class rex_api_minibar extends rex_api_function
                 $fragment = new rex_fragment([
                     'element' => $element,
                 ]);
-
+                rex_response::setStatus(rex_response::HTTP_OK); 
                 rex_response::sendContent($fragment->parse('core/minibar/minibar_element.php'));
                 exit();
             }


### PR DESCRIPTION
Fix für: https://github.com/yakamara/redaxo_yrewrite/issues/298