### PR TITLE
Session-Value für 'rex_syslog_last_seen' setzen

### DIFF
--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -9,7 +9,8 @@ class rex_minibar_element_syslog extends rex_minibar_element
     public function __construct()
     {
         if (rex::isBackend() && rex_be_controller::getCurrentPage() == 'system/log/redaxo') {
-            rex_set_session('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
+            $login = rex::getProperty('login');
+            $login->setSessionVar('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
         }
     }
 
@@ -21,8 +22,10 @@ class rex_minibar_element_syslog extends rex_minibar_element
         // in case someone else aready read the filemtime() and the file was changed afterwards within the same request
         clearstatcache( true, $sysLogFile );
         $lastModified = filemtime($sysLogFile);
+
         // "last-seen" will be updated, when the user looks into the syslog
-        $lastSeen = rex_session('rex_syslog_last_seen');
+        $login = rex::getProperty('login');
+        $lastSeen = $login->getSessionVar('rex_syslog_last_seen');
 
         // when the user never looked into the file (e.g. after login), we dont have a timely reference point.
         // therefore we check for changes in the file within the last 24hours

--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -9,6 +9,8 @@ class rex_minibar_element_syslog extends rex_minibar_element
     public function __construct()
     {
         if (rex::isBackend() && rex_be_controller::getCurrentPage() == 'system/log/redaxo') {
+            // use the backend-session instead of rex_session() to make it work consistently across frontend/backend.
+            // the frontend should reflect when we look into the log in the backend.
             $login = rex::getProperty('login');
             $login->setSessionVar('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
         }

--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -5,6 +5,15 @@
  */
 class rex_minibar_element_syslog extends rex_minibar_element
 {
+
+    public function __construct() {
+        if (rex_be_controller::getCurrentPage() == 'system/log/redaxo') {
+            rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
+                rex_set_session('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
+            });
+        }
+    }
+
     public function render()
     {
         $status = 'rex-syslog-ok';
@@ -21,7 +30,7 @@ class rex_minibar_element_syslog extends rex_minibar_element
                 $status = 'rex-syslog-changed';
             }
         } elseif ($lastModified && $lastModified > $lastSeen) {
-            $status = 'rex-syslog-changed';
+                       $status = 'rex-syslog-changed';
         }
 
         return

--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -6,11 +6,10 @@
 class rex_minibar_element_syslog extends rex_minibar_element
 {
 
-    public function __construct() {
-        if (rex_be_controller::getCurrentPage() == 'system/log/redaxo') {
-            rex_extension::register('OUTPUT_FILTER', function (rex_extension_point $ep) {
-                rex_set_session('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
-            });
+    public function __construct()
+    {
+        if (rex::isBackend() && rex_be_controller::getCurrentPage() == 'system/log/redaxo') {
+            rex_set_session('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
         }
     }
 
@@ -30,7 +29,7 @@ class rex_minibar_element_syslog extends rex_minibar_element
                 $status = 'rex-syslog-changed';
             }
         } elseif ($lastModified && $lastModified > $lastSeen) {
-                       $status = 'rex-syslog-changed';
+            $status = 'rex-syslog-changed';
         }
 
         return


### PR DESCRIPTION
Setzt beim Besuch der Syslog-Seite den Session-Value, so dass Besuche der Seite erkannt und die Syslog-Flagge grün oder gelb wird. 

Closes #53 