### PR TITLE
support rex_editor in syslog element

### DIFF
--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -26,7 +26,7 @@ class rex_minibar_element_syslog extends rex_minibar_element
             $status = 'rex-syslog-changed';
         }
 
-        return
+        $item =
             '<div class="rex-minibar-item">
                 <a href="'. rex_url::backendPage('system/log/redaxo') .'">
                     <span class="rex-minibar-icon">
@@ -37,6 +37,24 @@ class rex_minibar_element_syslog extends rex_minibar_element
                     </span>
                 </a>
         </div>';
+
+        $logFile = rex_logger::getPath();
+        $editor = rex_editor::factory();
+        $url = $editor->getUrl($logFile, 1);
+
+        $info = '';
+        if ($url) {
+            $info =
+                '<div class="rex-minibar-info">
+                    <div class="rex-minibar-info-group">
+                        <div class="rex-minibar-info-piece">
+                            <a href="'. $url .'">' . rex_i18n::msg('system_editor_open_file', basename($logFile)) . '</a>
+                        </div>
+                    </div>
+            </div>';
+        }
+
+        return $item . $info;
     }
 
     public function getOrientation()


### PR DESCRIPTION
wenn die editor integration im redaxo core aktiviert ist, kann man direkt aus der toolbar heraus das syslog im editor öffnen

![grafik](https://user-images.githubusercontent.com/120441/91660790-28689700-ead8-11ea-9287-29daeafd25ff.png)

kann gerne von jemandem noch optisch gepimped werden