### PR TITLE
Debug info added

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -10,6 +10,9 @@ rex_minibar::getInstance()->addElement(new rex_minibar_element_syslog());
 if (rex::isFrontend() || (rex::isBackend() && (rex_be_controller::getCurrentPagePart(1) === 'content' || rex_be_controller::getCurrentPagePart(1) === 'structure'))) {
     rex_minibar::getInstance()->addElement(new rex_minibar_element_structure_article());
 }
+if (rex::isFrontend() && rex::isDebugMode()) {
+    rex_minibar::getInstance()->addElement(new rex_minibar_element_debug());
+}
 
 if (rex::isBackend()) {
     if (rex_be_controller::getCurrentPagePart(1) == 'system') {

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -32,4 +32,9 @@ minibar_metainfo_hide = verbergen
 minibar_metainfo_show = anzeigen
 minibar_system_info = System
 
-
+minibar_debug_header = Der Debug-Modus ist aktiviert
+minibar_debug_info = Info
+minibar_debug_info_text = Debug sollte nicht in Live-Systemen aktiviert werden.<br>Kontatkiere ggf. einen Administrator
+minibar_debug_links = Links
+minibar_debug_system_settings = Systemeinstellungen
+minibar_debug_start_debug = Debug-AddOn aufrufen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -33,3 +33,9 @@ minibar_metainfo_show = show
 minibar_system_info = System
 
 
+minibar_debug_header = Debug mode is activated
+minibar_debug_info = Info
+minibar_debug_info_text = Debug should not be enabled on live systems.<br>Contact an administrator if needed.
+minibar_debug_links = Links
+minibar_debug_system_settings = System settings
+minibar_debug_start_debug = Open debug addon

--- a/lib/element/debug.php
+++ b/lib/element/debug.php
@@ -20,12 +20,15 @@ class rex_minibar_element_debug extends rex_minibar_element
                     <span>
                         <a href="/redaxo/index.php?page=system">'.rex_i18n::msg('minibar_debug_system_settings').'</a>
                     </span>
-                    <br>
-			<span>
-                        <a href="/redaxo/index.php?page=debug" target="_blank">'.rex_i18n::msg('minibar_debug_start_debug').'</a>
-                    	</span>
-                </div>
-';
+                    <br>';
+if (rex_addon::get('debug')->isAvailable())	
+{
+	 $links .= '<span>
+                 <a href="/redaxo/index.php?page=debug" target="_blank">'.rex_i18n::msg('minibar_debug_start_debug').'</a>
+         </span>
+';}
+
+ $links .= '</div>';
 }    
         return
         '

--- a/lib/element/debug.php
+++ b/lib/element/debug.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Quick Navigation package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+class rex_minibar_element_debug extends rex_minibar_element
+{
+    public function render()
+    {
+        return
+        '
+        <style>
+        .rex-minibar-debug {
+    animation:rex-pulse 5s ease infinite;
+	color: #f09000;
+}
+@keyframes rex-pulse {
+    0% {
+        transform:scale(1)
+    }
+
+    5% {
+        transform:scale(1.15)
+    }
+
+    20% {
+        transform:scale(1)
+    }
+
+    30% {
+        transform:scale(1)
+    }
+
+    35% {
+        transform:scale(1.15)
+    }
+
+    50% {
+        transform:scale(1)
+    }
+
+    55% {
+        transform:scale(1.25)
+    }
+
+    70% {
+        transform:scale(1)
+    }
+}
+
+        </style>
+        <div class="rex-minibar-item">
+            <span class="rex-minibar-icon">
+                <i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i> 
+            </span>
+            <span class="rex-minibar-value">
+            Debug
+            </span>
+        </div>
+<div class="rex-minibar-info">
+        <div class="rex-minibar-info-header"><i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i>  '.rex_i18n::msg('minibar_debug_header').'</div>
+            <div class="rex-minibar-info-group">
+                <div class="rex-minibar-info-piece">
+                    <span class="title">'.rex_i18n::msg('minibar_debug_info').'</span>
+                    <span>
+                        '.rex_i18n::msg('minibar_debug_info_text').'
+                    </span>
+                </div>
+                <div class="rex-minibar-info-piece">
+                    <span class="title">'.rex_i18n::msg('minibar_debug_links').'</span>
+                    <span>
+                        <a href="/redaxo/index.php?page=system">'.rex_i18n::msg('minibar_debug_system_settings').'</a>
+                    </span>
+                    <br>
+					<span>
+                        <a href="/redaxo/index.php?page=debug" target="_blank">'.rex_i18n::msg('minibar_debug_start_debug').'</a>
+                    </span>
+                </div>
+            </div>
+        </div>
+        ';
+    }
+
+    public function getOrientation()
+    {
+        return rex_minibar_element::RIGHT;
+    }
+}

--- a/lib/element/debug.php
+++ b/lib/element/debug.php
@@ -12,6 +12,21 @@ class rex_minibar_element_debug extends rex_minibar_element
 {
     public function render()
     {
+	$links = '';    
+	if (rex::getUser()->isAdmin()) {
+	    $links = '	    
+                <div class="rex-minibar-info-piece">
+                    <span class="title">'.rex_i18n::msg('minibar_debug_links').'</span>
+                    <span>
+                        <a href="/redaxo/index.php?page=system">'.rex_i18n::msg('minibar_debug_system_settings').'</a>
+                    </span>
+                    <br>
+			<span>
+                        <a href="/redaxo/index.php?page=debug" target="_blank">'.rex_i18n::msg('minibar_debug_start_debug').'</a>
+                    	</span>
+                </div>
+';
+}    
         return
         '
         <style>
@@ -59,7 +74,7 @@ class rex_minibar_element_debug extends rex_minibar_element
                 <i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i> 
             </span>
             <span class="rex-minibar-value">
-            Debug
+            '.rex_i18n::msg('debug_mode').'
             </span>
         </div>
 <div class="rex-minibar-info">
@@ -71,16 +86,7 @@ class rex_minibar_element_debug extends rex_minibar_element
                         '.rex_i18n::msg('minibar_debug_info_text').'
                     </span>
                 </div>
-                <div class="rex-minibar-info-piece">
-                    <span class="title">'.rex_i18n::msg('minibar_debug_links').'</span>
-                    <span>
-                        <a href="/redaxo/index.php?page=system">'.rex_i18n::msg('minibar_debug_system_settings').'</a>
-                    </span>
-                    <br>
-					<span>
-                        <a href="/redaxo/index.php?page=debug" target="_blank">'.rex_i18n::msg('minibar_debug_start_debug').'</a>
-                    </span>
-                </div>
+             '.$links.'
             </div>
         </div>
         ';
@@ -91,3 +97,4 @@ class rex_minibar_element_debug extends rex_minibar_element
         return rex_minibar_element::RIGHT;
     }
 }
+

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: minibar
-version: '2.1.1'
+version: '2.2.0'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/minibar
 


### PR DESCRIPTION
With pulse animation
and further info

<img width="832" alt="Bildschirmfoto 2021-01-09 um 18 00 47" src="https://user-images.githubusercontent.com/791247/104103844-a3229980-52a4-11eb-9cd5-ac31323790a4.png">
