### PR TITLE
Gelbes Logfile-Fähnchen: clearstatcache() auch im Constructor

### DIFF
--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -12,7 +12,7 @@ class rex_minibar_element_syslog extends rex_minibar_element
             // use the backend-session instead of rex_session() to make it work consistently across frontend/backend.
             // the frontend should reflect when we look into the log in the backend.
             $login = rex::getProperty('login');
-            clearstatcache( true, $sysLogFile );
+            clearstatcache( true, rex_logger::getPath());
             $login->setSessionVar('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
         }
     }

--- a/lib/element/syslog.php
+++ b/lib/element/syslog.php
@@ -12,6 +12,7 @@ class rex_minibar_element_syslog extends rex_minibar_element
             // use the backend-session instead of rex_session() to make it work consistently across frontend/backend.
             // the frontend should reflect when we look into the log in the backend.
             $login = rex::getProperty('login');
+            clearstatcache( true, $sysLogFile );
             $login->setSessionVar('rex_syslog_last_seen', filemtime(rex_logger::getPath()) );
         }
     }


### PR DESCRIPTION
Hatten wir schon einmal (#67) so ähnlich. Ich habe mich gewundert, dass die gelbe Fahne nach dem Löschen des Syslog sofort wieder da war.

Daher habe ich wie in der Lösung damals `clearstatcache()` in den Constructor genomen, denn da wird auch ein `filemstat()` ausgeführt. 