### PR TITLE
Scheme-Umschalter (Dark-Light-Mode)

### DIFF
--- a/assets/minibar.js
+++ b/assets/minibar.js
@@ -7,7 +7,6 @@ $(document).on('rex:ready', function (event, container) {
     /** 
      * Für den Scheme-Umschalter (Light/Dark-Mode)
      */
-    console.log(rex);
     if (typeof rex === 'object' && rex.theme && redaxo.theme && !redaxo.minibar ) {
         redaxo.minibar = function (theme) {
             if( theme == 'reset' ){

--- a/assets/minibar.js
+++ b/assets/minibar.js
@@ -3,4 +3,30 @@ $(document).on('rex:ready', function (event, container) {
     if (minibar.length) {
         $('body > .rex-minibar').replaceWith(minibar);
     }
+
+    /** 
+     * Für den Scheme-Umschalter (Light/Dark-Mode)
+     */
+    console.log(rex);
+    if (typeof rex === 'object' && rex.theme && redaxo.theme && !redaxo.minibar ) {
+        redaxo.minibar = function (theme) {
+            if( theme == 'reset' ){
+                theme = rex.theme;
+            }
+            if( theme == redaxo.theme.current ){
+                return;
+            }
+            if( theme === 'auto' ) {
+                document.body.classList.remove('rex-theme-dark');
+                document.body.classList.remove('rex-theme-light');
+                return;
+            }
+            document.body.classList.remove('rex-theme-'+redaxo.theme.current);
+            document.body.classList.add('rex-theme-'+theme)
+        };
+        let node = document.getElementById('mb-8d502110-db8a-4355-baaa-a612778fb4aa');
+        if( node ) {
+            node.innerHTML = rex.theme;
+        }
+    }
 });

--- a/boot.php
+++ b/boot.php
@@ -6,7 +6,6 @@ $addon = rex_addon::get('minibar');
 rex_minibar::getInstance()->addElement(new rex_minibar_element_system());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_time());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_syslog());
-rex_minibar::getInstance()->addElement(new rex_minibar_element_scheme());
 
 if (rex::isFrontend() || (rex::isBackend() && (rex_be_controller::getCurrentPagePart(1) === 'content' || rex_be_controller::getCurrentPagePart(1) === 'structure'))) {
     rex_minibar::getInstance()->addElement(new rex_minibar_element_structure_article());
@@ -16,6 +15,8 @@ if (rex::isFrontend() && rex::isDebugMode()) {
 }
 
 if (rex::isBackend()) {
+    rex_minibar::getInstance()->addElement(new rex_minibar_element_scheme());
+    
     if (rex_be_controller::getCurrentPagePart(1) == 'system') {
         rex_system_setting::register(new rex_system_setting_minibar());
         rex_system_setting::register(new rex_system_setting_minibar_inpopup());

--- a/boot.php
+++ b/boot.php
@@ -6,6 +6,7 @@ $addon = rex_addon::get('minibar');
 rex_minibar::getInstance()->addElement(new rex_minibar_element_system());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_time());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_syslog());
+rex_minibar::getInstance()->addElement(new rex_minibar_element_scheme());
 
 if (rex::isFrontend() || (rex::isBackend() && (rex_be_controller::getCurrentPagePart(1) === 'content' || rex_be_controller::getCurrentPagePart(1) === 'structure'))) {
     rex_minibar::getInstance()->addElement(new rex_minibar_element_structure_article());

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -38,3 +38,10 @@ minibar_debug_info_text = Debug sollte nicht in Live-Systemen aktiviert werden.<
 minibar_debug_links = Links
 minibar_debug_system_settings = Systemeinstellungen
 minibar_debug_start_debug = Debug-AddOn aufrufen
+
+minibar_scheme_title = Dark/Light-Mode
+minibar_scheme_default = Default
+minibar_scheme_dark = Dark
+minibar_scheme_light = Light
+minibar_scheme_auto = Auto
+minibar_scheme_reset = Reset

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -39,3 +39,10 @@ minibar_debug_info_text = Debug should not be enabled on live systems.<br>Contac
 minibar_debug_links = Links
 minibar_debug_system_settings = System settings
 minibar_debug_start_debug = Open debug addon
+
+minibar_scheme_title = Dark/Light-Mode
+minibar_scheme_default = Default
+minibar_scheme_dark = Dark
+minibar_scheme_light = Light
+minibar_scheme_auto = Auto
+minibar_scheme_reset = Reset

--- a/lib/element/scheme.php
+++ b/lib/element/scheme.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Schaltet die Schemes um:
+ *  - Dark-Mode
+ *  - Light-Mode
+ *  - Automatische Umstaltung gem Systemeinstellung (kann nicht jeder Browser)
+ *  - Reset auf Grundeinstellung des Users.
+ * 
+ * Siehe JS für die konkrete Umschaltung
+ *
+ * @package redaxo\core\minibar
+ */
+class rex_minibar_element_scheme extends rex_minibar_element
+{
+    public function render()
+    {
+        if (rex::isFrontend()) {
+            return '';
+        }
+        return '<div class="rex-minibar-item">
+                <span class="rex-minibar-value">
+                    <span class="rex-js-script-time">&#128161; '.rex_i18n::msg('minibar_scheme_title').'</span>
+                </span>
+            </div>
+            <div class="rex-minibar-info">
+                <div class="rex-minibar-info-group">
+                    <div class="rex-minibar-info-piece">
+                        '.rex_i18n::msg('minibar_scheme_default').': <span id="mb-8d502110-db8a-4355-baaa-a612778fb4aa"></span>
+                    </div>
+                    <div class="rex-minibar-info-piece">
+                        &rArr; <a href="javascript:redaxo.minibar(\'dark\');">'.rex_i18n::msg('minibar_scheme_dark').'</a>
+                    </div>
+                    <div class="rex-minibar-info-piece">
+                        &rArr; <a href="javascript:redaxo.minibar(\'light\');">'.rex_i18n::msg('minibar_scheme_light').'</a>
+                    </div>
+                    <div class="rex-minibar-info-piece">
+                        &rArr; <a href="javascript:redaxo.minibar(\'auto\');">'.rex_i18n::msg('minibar_scheme_auto').'</a>
+                    </div>
+                    <div class="rex-minibar-info-piece">
+                        &rArr; <a href="javascript:redaxo.minibar(\'reset\');">'.rex_i18n::msg('minibar_scheme_reset').'</a>
+                    </div>
+                </div>
+            </div>';
+    }
+
+    public function getOrientation()
+    {
+        return rex_minibar_element::RIGHT;
+    }
+}

--- a/lib/element/scheme.php
+++ b/lib/element/scheme.php
@@ -15,9 +15,6 @@ class rex_minibar_element_scheme extends rex_minibar_element
 {
     public function render()
     {
-        if (rex::isFrontend()) {
-            return '';
-        }
         return '<div class="rex-minibar-item">
                 <span class="rex-minibar-value">
                     <span class="rex-js-script-time">&#128161; '.rex_i18n::msg('minibar_scheme_title').'</span>


### PR DESCRIPTION
Ein kleines Minibar-Element, mit dem der Dark-Mode fix getestet werden kann. Die Umschaltung erfolgt auf der laufenden Seite durch Änderung der Klassen auf dem body-Tag. Neu Laden der Seite ist also nicht erforderlich!

<img width="312" alt="grafik" src="https://github.com/FriendsOfREDAXO/minibar/assets/10065904/520cced6-d4e0-4ea5-8bff-636df32bf2af">
