### PR TITLE
Cache Löschen

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,5 +1,7 @@
 <?php
 
+use FriendsOfRedaxo\Minibar\Api\ClearCache;
+
 $addon = rex_addon::get('minibar');
 
 
@@ -21,6 +23,7 @@ $addon = rex_addon::get('minibar');
 rex_minibar::getInstance()->addElement(new rex_minibar_element_system());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_time());
 rex_minibar::getInstance()->addElement(new rex_minibar_element_syslog());
+rex_api_function::register('mbclrcache', ClearCache::class);
 
 // URL2/YForm Element für alle Backend-Bereiche verfügbar machen
 if (rex::isFrontend()) {

--- a/lib/Api/ClearCache.php
+++ b/lib/Api/ClearCache.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * API-Klasse zum Löschen des Caches
+ * 
+ * Es wird stets der gesamte Cache gelöscht.
+ */
+
+namespace FriendsOfRedaxo\Minibar\Api;
+
+use rex_api_function;
+use rex_response;
+
+class ClearCache extends rex_api_function
+{
+
+    // Nur im Backend
+    protected $published = false;
+
+    public function execute()
+    {
+        rex_delete_cache();
+        rex_response::cleanOutputBuffers();
+        rex_response::setStatus(rex_response::HTTP_OK);
+        rex_response::sendContent(rex_response::HTTP_OK);
+        exit;
+    }
+}

--- a/lib/element/system.php
+++ b/lib/element/system.php
@@ -1,5 +1,7 @@
 <?php
 
+use FriendsOfRedaxo\Minibar\Api\ClearCache;
+
 /**
  * @package redaxo\core\minibar
  */
@@ -12,6 +14,15 @@ class rex_minibar_element_system extends rex_minibar_element
         $links = '';
         if (rex::getUser() && rex::getUser()->isAdmin()) {
             $links .= '<a href="https://redaxo.org/doku/master" target="_blank" rel="help noreferrer noopener">'.rex_i18n::msg('minibar_documentation_link_label').'</a>';
+        }
+
+        $clearCache = '';
+        if (rex::getUser() && rex::getUser()->isAdmin()) {
+            $clearCache = sprintf(
+                '<br><a href="javascript:(fetch(\'%s\'))">%s</a>',
+                rex_url::currentBackendPage(ClearCache::getUrlParams(),false),
+                rex_escape( rex_i18n::msg('delete_cache')),
+            );
         }
 
         $logo = str_replace('<svg ', '<svg class="rex-redaxo-logo" ', (string) rex_file::get(rex_url::coreAssets('redaxo-logo.svg')));
@@ -29,7 +40,7 @@ class rex_minibar_element_system extends rex_minibar_element
             <div class="rex-minibar-info-group">
                 <div class="rex-minibar-info-piece">
                     <span class="title">REDAXO</span>
-                    <span>'.rex::getVersion().' '.(rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="'.rex_escape(rex_i18n::msg('logfiles')).'">'.rex_i18n::msg('logfiles').'</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="'.rex_escape(rex_i18n::msg('system_report')).'">'.rex_i18n::msg('system_report').'</a>' : '') .'</span>
+                    <span>'.rex::getVersion().' '.(rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="'.rex_escape(rex_i18n::msg('logfiles')).'">'.rex_i18n::msg('logfiles').'</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="'.rex_escape(rex_i18n::msg('system_report')).'">'.rex_i18n::msg('system_report').'</a>'.$clearCache : '') .'</span>
                 </div>
                 <div class="rex-minibar-info-piece">
                     <span class="title">PHP Version</span>

--- a/lib/element/system.php
+++ b/lib/element/system.php
@@ -17,7 +17,7 @@ class rex_minibar_element_system extends rex_minibar_element
         }
 
         $clearCache = '';
-        if (rex::getUser() && rex::getUser()->isAdmin()) {
+        if (rex::getUser() && rex::getUser()->isAdmin() && rex::isDebugMode()) {
             $clearCache = sprintf(
                 '<br><a href="javascript:(fetch(\'%s\'))">%s</a>',
                 rex_url::currentBackendPage(ClearCache::getUrlParams(),false),


### PR DESCRIPTION
Im System-Menü zusätzlich einen Aufruf "Cache-Löschen" hinzugefügt. Das ist ganz hilfreich, wenn man die Seite z.B. wegen grade getätigter Eingaben nicht verlsssen will, aber dennoch schnell mal den Cache gelöscht haben muss.

Keine große Sache, einfach per API-Call den **gesamten** Cache löschen; nur für Admins verfügbar. **Ich habe bewusst auf eine einfache Lösung gesetzt.**

<img width="547" height="469" alt="grafik" src="https://github.com/user-attachments/assets/1ab487ef-2398-4246-b23b-87c13e286331" />

 Man könnte das noch weiter ausarbeiten, hab ich mir aber erspart.

- Z.B. über ein eigenes Cache-Löschen-Element, in dem differenziert wird:
  - Gesamten Cache löschen
  - Autoload-Cache löschen (aka `cache/core/autoload.cache`)
  - Core-Cache löschen (aka `cache/core/*`)
  - Artikel-Cache lschen (aka `cache/addons/structure/*`)
  - weitere Addons könnten sich per EP einhängen?
- ausgefuchsteres JS
  - Rückmeldung des API-Calls auswerten
  - Vollzugsmeldung anzeigen