### PR TITLE
Custom-Lazy-Elemente mit Namespace handhaben

### DIFF
--- a/fragments/minibar/minibar_element.php
+++ b/fragments/minibar/minibar_element.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * @var $element rex_minibar_element
+ * @var rex_minibar_element $element 
  */
 $element = $this->element;
 
 $class = 'rex-minibar-element ';
-$class .= rex_string::normalize(get_class($element), '-');
+$class .= $element->cssClass();
 $class .= ($element->getOrientation() == rex_minibar_element::RIGHT ? ' rex-minibar-element-right' : '');
 $class .= ($element->isDanger() ? ' rex-minibar-status-danger' : '');
 $class .= ($element->isWarning() ? ' rex-minibar-status-warning' : '');

--- a/fragments/minibar/minibar_element.php
+++ b/fragments/minibar/minibar_element.php
@@ -13,7 +13,7 @@ $class .= ($element->isPrimary() ? ' rex-minibar-status-primary' : '');
 
 $onmouseover = '';
 if ($element instanceof rex_minibar_lazy_element && rex_minibar_lazy_element::isFirstView()) {
-    $elementId = get_class($element);
+    $elementId = $element->jsId();
     $context = rex_context::restore();
     $url = $context->getUrl(['lazy_element' => $elementId, 'article_id' => rex_article::getCurrentId(), 'current_lang'=> rex_clang::getCurrentId()] + rex_api_minibar::getUrlParams());
     $onmouseover = <<<EOD

--- a/lib/element/element.php
+++ b/lib/element/element.php
@@ -18,6 +18,35 @@ abstract class rex_minibar_element
     abstract public function render();
 
     /**
+     * liefert einen CSS-Namen, über den Elemente dieser Klasse
+     * individuell konfiguriert werden können.
+     * 
+     * Für eigene Klassen: optional überschreiben
+     * 
+     * Default: normalisierter Klassenname
+     * 
+     * @api
+     */
+    public function cssClass() : string
+    {
+        return rex_string::normalize(static::class, '-');
+    }
+
+    /**
+     * Liefert einen anonymisierten Identifier zur Verwendung in API-Aufrufen
+     * MD5-kodierter Pfadname
+     * 
+     * Dem Hack ist ein M vorangestellt, das JS-Identifier mit eine Buchstaben
+     * beginnen müssen/sollten
+     * 
+     * @api
+     */
+    public function jsId() : string
+    {
+        return 'M' . md5(static::class);
+    }
+
+    /**
      * Returns the orientation in the minibar.
      *
      * @return string `rex_minibar_element::LEFT` or `rex_minibar_element::RIGHT`

--- a/lib/element/element.php
+++ b/lib/element/element.php
@@ -36,7 +36,7 @@ abstract class rex_minibar_element
      * Liefert einen anonymisierten Identifier zur Verwendung in API-Aufrufen
      * MD5-kodierter Pfadname
      * 
-     * Dem Hash ist ein M vorangestellt, das JS-Identifier mit eine Buchstaben
+     * Dem Hash ist ein M vorangestellt, da JS-Identifier mit einem Buchstaben
      * beginnen müssen/sollten
      * 
      * @api

--- a/lib/element/element.php
+++ b/lib/element/element.php
@@ -29,12 +29,13 @@ abstract class rex_minibar_element
      */
     public function cssClass() : string
     {
-        return rex_string::normalize(static::class, '-');
+        static $cache = [];
+        return $cache[static::class] ??= rex_string::normalize(static::class, '-');
     }
 
     /**
      * Liefert einen anonymisierten Identifier zur Verwendung in API-Aufrufen
-     * MD5-kodierter Pfadname
+     * MD5-kodierter Klassenname
      * 
      * Dem Hash ist ein M vorangestellt, da JS-Identifier mit einem Buchstaben
      * beginnen müssen/sollten
@@ -43,7 +44,8 @@ abstract class rex_minibar_element
      */
     public function jsId() : string
     {
-        return 'M' . md5(static::class);
+        static $cache = [];
+        return $cache[static::class] ??= 'M' . md5(static::class);
     }
 
     /**

--- a/lib/element/element.php
+++ b/lib/element/element.php
@@ -36,7 +36,7 @@ abstract class rex_minibar_element
      * Liefert einen anonymisierten Identifier zur Verwendung in API-Aufrufen
      * MD5-kodierter Pfadname
      * 
-     * Dem Hack ist ein M vorangestellt, das JS-Identifier mit eine Buchstaben
+     * Dem Hash ist ein M vorangestellt, das JS-Identifier mit eine Buchstaben
      * beginnen müssen/sollten
      * 
      * @api

--- a/lib/minibar.php
+++ b/lib/minibar.php
@@ -36,6 +36,7 @@ class rex_minibar
                 return $element;
             }
         }
+        return null;
     }
 
     public function get()

--- a/lib/minibar.php
+++ b/lib/minibar.php
@@ -21,6 +21,10 @@ class rex_minibar
     }
 
     /**
+     * Identifiziert eine Elementklasse entweder über den Klassennamen im Klartext
+     * oder über den als MD5 kodierten Klassennamen.
+     * (zur Info, dem Hash stgeht ein M voran)
+     * 
      * @param string $className
      *
      * @return rex_minibar_element|null
@@ -28,7 +32,7 @@ class rex_minibar
     public function elementByClass($className)
     {
         foreach ($this->elements as $element) {
-            if (get_class($element) === $className) {
+            if ($element::class === $className || $element->jsId() === $className) {
                 return $element;
             }
         }

--- a/lib/minibar.php
+++ b/lib/minibar.php
@@ -23,7 +23,7 @@ class rex_minibar
     /**
      * Identifiziert eine Elementklasse entweder über den Klassennamen im Klartext
      * oder über den als MD5 kodierten Klassennamen.
-     * (zur Info, dem Hash stgeht ein M voran)
+     * (zur Info, dem Hash steht ein M voran)
      * 
      * @param string $className
      *


### PR DESCRIPTION
siehe #97 

Der PR basisert auf der Lösungsvariante 3 des Issues:
> Ersetze den als js-Identifier benutzten Klassennamen durch einen auf dem md5-Hash des Klassennamens (ggf. mit Namespace) basierenden Identifier.

Details zur Lösung:
- da ein Identifier nicht mit einer Ziffer beginnen darf, wird der Buchstabe M dem Hash vorangestellt.
- Der Hash-basierte Identifier wird von einer Methode der Klasse `element` des Addons erzeugt.
- In der Klasse `rex_minifier` ist die Suche nach dem passenden Element via Klassenname (`->elementByClass(...)`) erweitert auf "Klassenname oder Klassenname-basierter Hash".
- Der Klassenname wird auch als CSS-Klasse eingefügt. Auch das wurde bei der Gelegenheit auf den Aufruf einer Methode der Element-Klasse geändert. Das erlaubt in Curtom-Elementen einen individuellen CSS-Namen zu verwenden.
- Nebenbei einen PHPDOC-Fehler behoben.

Keine Änderungen in der Doku; die Änderungen betreffen Hintergrundaktionen. Bzgl. der Element-basiserten CSS-Klasse gibt es jetzt keine Hinweise in der Doku; zumindest habe ich keine gefunden. Daher habe ich auch keinen Passus zur neuen Methode `elementklasse->cssClass()` geschrieben.

Mit einem Custom-Lazy-Element mit Namespace erfolgreich getestet.

@skerbis Falls Du als Maintainer der Meinung bist, dass die Änderungen einen BC darstellen und deshalb ein Major-Relase 3.0 erzeugt werden müsste, bitte ich Dich, damit noch zu warten. Für das nächste Major-Release würde ich das Addon gerne komplett auf Namespace umstellen.