### PR TITLE
RexStan und Kommentare

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Api\ClearCache;
 use FriendsOfRedaxo\Minibar\Api\LazyLoader;
 use FriendsOfRedaxo\Minibar\Element\Debug;
@@ -14,13 +23,17 @@ use FriendsOfRedaxo\Minibar\Settings\HideEmptyMetainfos;
 use FriendsOfRedaxo\Minibar\Settings\MinibarInPopup;
 use FriendsOfRedaxo\Minibar\Settings\Scope;
 
+/**
+ * @var rex_addon $this
+ * @psalm-scope-this rex_addon
+ */
+
 /** TODO: Kann man die boot.php entschlacken und Codeblöcke außerhalb parken (static-Methoden)? Nur compilieren was wirklich notwendig ist. */
 
-/** TODO: das "$mypage = 'minibar'" vorziehen und auch hier nutzen */
 $addon = rex_addon::get('minibar');
 
 /** TODO: Muss denn wirklich vor jedem Aufruf die Kompilierung geprüft weden? Reicht es nicht in der install.php? */
-if (class_exists('rex_scss_compiler') && $addon->getConfig('compile')) {
+if (class_exists('rex_scss_compiler') && $addon->getConfig('compile', false) !== false) {
     $compiler = new rex_scss_compiler();
 
     $compiler->setRootDir(rex_path::addon('minibar/scss'));
@@ -32,32 +45,29 @@ if (class_exists('rex_scss_compiler') && $addon->getConfig('compile')) {
     $addon->setConfig('compile', false);
 }
 
-$mypage = 'minibar';
-/** TODO: na dann bitte auch "rex_addon::get($mypage)" */
-$addon = rex_addon::get('minibar');
+$minibar = Minibar::getInstance();
+$minibar->addElement(new System());
+$minibar->addElement(new Time());
+$minibar->addElement(new Syslog());
 
-/** TODO: Instanz nur einmal abrufenn und als Variable nutzen "$minibar = Minibar::getInstance(); $minibar->addelemene..." */
-Minibar::getInstance()->addElement(new System());
-Minibar::getInstance()->addElement(new Time());
-Minibar::getInstance()->addElement(new Syslog());
 rex_api_function::register('mbclrcache', ClearCache::class);
-rex_api_function::register('minibar', LazyLoader::class);
+rex_api_function::register('mblzyld', LazyLoader::class);
 
 // URL2/YForm Element für alle Backend-Bereiche verfügbar machen
 if (rex::isFrontend()) {
-Minibar::getInstance()->addElement(new Url2Yform());
+    $minibar->addElement(new Url2Yform());
 }
 if (rex::isFrontend() || (rex::isBackend() && (rex_be_controller::getCurrentPagePart(1) === 'content' || rex_be_controller::getCurrentPagePart(1) === 'structure'))) {
-    Minibar::getInstance()->addElement(new StructureArticle());
+    $minibar->addElement(new StructureArticle());
 }
 if (rex::isFrontend() && rex::isDebugMode()) {
-    Minibar::getInstance()->addElement(new Debug());
+    $minibar->addElement(new Debug());
 }
 
 if (rex::isBackend()) {
-    Minibar::getInstance()->addElement(new Scheme());
+    $minibar->addElement(new Scheme());
     
-    if (rex_be_controller::getCurrentPagePart(1) == 'system') {
+    if (rex_be_controller::getCurrentPagePart(1) === 'system') {
         rex_system_setting::register(new Scope());
         rex_system_setting::register(new MinibarInPopup());
         rex_system_setting::register(new HideEmptyMetainfos());
@@ -76,9 +86,8 @@ if (rex::isBackend()) {
 
     rex_extension::register('PAGE_CHECKED', static function (rex_extension_point $ep) {
         $page = rex_be_controller::getCurrentPageObject();
-        if ($page && $page->isPopup()) {
-            $enabled = rex_config::get('minibar', 'inpopup_enabled', MinibarInPopup::DISABLED);
-            Minibar::getInstance()->setActive($enabled == MinibarInPopup::ENABLED);
+        if (null !==$page && $page->isPopup()) {
+            Minibar::getInstance()->setActive(MinibarInPopup::isEnabled());
         }
     });
 
@@ -88,7 +97,7 @@ if (rex::isBackend()) {
     }
 
     // XXX vermutlich nicht mehr nötig?
-    // TODO: prüfen und dann rauswerfen
+    // TODO: na dann prüfen und dann rauswerfen
     // update body class if minibar has been set inactive
     rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
         if (Minibar::getInstance()->isActive() === false) {
@@ -103,7 +112,7 @@ if (rex::isBackend()) {
     // minibar aktualisieren bei PJAX requests.
     // in full-page requests wird die minibar via fragments/core/bottom.php gerendert.
     if (rex_request::isPJAXRequest()) {
-        rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) use ($addon) {
+        rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
             // replace last occrance within a string
             // credits to https://stackoverflow.com/questions/3835636/php-replace-last-occurrence-of-a-string-in-a-string
             $str_lreplace = static function ($search, $replace, $subject) {
@@ -117,7 +126,7 @@ if (rex::isBackend()) {
             };
 
             $minibar = Minibar::getInstance()->get();
-            if ($minibar) {
+            if (null !== $minibar) {
                 $pjaxResp = $str_lreplace('</section>', "\n". $minibar . '</section>', $ep->getSubject());
                 $ep->setSubject($pjaxResp);
             }
@@ -129,7 +138,7 @@ if (rex::isFrontend()) {
     rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) use ($addon) {
         $minibar = Minibar::getInstance()->get();
 
-        if ($minibar) {
+        if (null !== $minibar) {
             $ep->setSubject(str_ireplace(
                     ['</head>', '</body>'],
                     ['<link rel="stylesheet" type="text/css" href="' . $addon->getAssetsUrl('styles.css') .'" /></head>', $minibar . '</body>'],

--- a/extensions/extension_metainfo.php
+++ b/extensions/extension_metainfo.php
@@ -93,7 +93,7 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
             }
         }
 
-        if (''=== $value && $showMetaInfo === HideEmptyMetainfos::HIDE) {
+        if ('' === trim($value) && $showMetaInfo === HideEmptyMetainfos::HIDE) {
             continue;
         }
 

--- a/extensions/extension_metainfo.php
+++ b/extensions/extension_metainfo.php
@@ -1,5 +1,17 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Sub-code to boot.php: registers extension points to manage metainfo values of
+ * article and clang to the minibar.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 /** TODO: diesen Code-Block gemäß aktueller Vorgehensweise in eine Klasse überführen */
 
 use FriendsOfRedaxo\Minibar\Settings\HideEmptyMetainfos;
@@ -18,25 +30,26 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
         WHERE `f`.`name` LIKE :art OR `f`.`name` LIKE :cat 
         ORDER BY LEFT(`f`.`name`, 4), priority', ['art' => 'art_%', 'cat' => 'cat_%']);
 
-    if (!count($fields)) {
+    if (0 === count($fields)) {
         return null;
     }
 
+    /** @var rex_article $article */
     $article = $ep->getParam('article');
 
     $items = [];
     foreach ($fields as $field) {
         // Durch das unterschiedliche Erstellen der Optionen (Pipe, Sql) können die dazugehörigen Labels nicht ganz so einfach aufgelöst werden
         // Ein Admin sieht daher die gespeicherten Werte, ein Redakteur kann damit weniger anfangen
-        if (!rex::getUser()->isAdmin() && in_array($field['label'], ['checkbox', 'radio', 'select'])) {
+        if (!rex::getUser()->isAdmin() && in_array($field['label'], ['checkbox', 'radio', 'select'], true)) {
             continue;
         }
-        if (in_array($field['label'], ['legend'])) {
+        if (in_array($field['label'], ['legend'], true)) {
             continue;
         }
 
         $value = $article->getValue($field['name']);
-        if (trim($value) != '') {
+        if (trim($value) !== '') {
             switch ($field['label']) {
                 case 'REX_MEDIA_WIDGET':
                     $value = sprintf('<a href="%s" target="_blank">%s</a>', rex_url::media($value), $value);
@@ -51,7 +64,7 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
                     break;
                 case 'REX_LINK_WIDGET':
                     $linkedArticle = rex_article::get($value);
-                    if (!$linkedArticle) {
+                    if (null === $linkedArticle) {
                         break;
                     }
                     $value = sprintf('<a href="%s" target="_blank">%s</a>', $linkedArticle->getUrl(), $linkedArticle->getName());
@@ -60,8 +73,8 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
                     $values = explode(',', $value);
                     $value = [];
                     foreach ($values as $articleId) {
-                        $linkedArticle = rex_article::get($articleId);
-                        if (!$linkedArticle) {
+                        $linkedArticle = rex_article::get((int) $articleId);
+                        if (null === $linkedArticle) {
                             continue;
                         }
                         $value[] = sprintf('<a href="%s">%s</a>', $linkedArticle->getUrl(), $linkedArticle->getName());
@@ -69,18 +82,18 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
                     $value = implode(' | ', $value);
                     break;
                 case 'date':
-                    $value = rex_formatter::strftime($value);
+                    $value = rex_formatter::intlDate($value);
                     break;
                 case 'datetime':
-                    $value = rex_formatter::strftime($value, 'datetime');
+                    $value = rex_formatter::intlDateTime($value);
                     break;
                 case 'time':
-                    $value = rex_formatter::strftime($value, 'time');
+                    $value = rex_formatter::intlTime($value);
                     break;
             }
         }
 
-        if (!$value && $showMetaInfo === HideEmptyMetainfos::HIDE) {
+        if (''=== $value && $showMetaInfo === HideEmptyMetainfos::HIDE) {
             continue;
         }
 
@@ -93,7 +106,7 @@ rex_extension::register('MINIBAR_ARTICLE', static function (rex_extension_point 
         $items[] = $item;
     }
 
-    if (!$items && $showMetaInfo === HideEmptyMetainfos::HIDE) {
+    if (0 === count($items) && $showMetaInfo === HideEmptyMetainfos::HIDE) {
         return null;
     }
 
@@ -113,10 +126,11 @@ rex_extension::register('MINIBAR_CLANG', static function (rex_extension_point $e
     // $sqlFields->setDebug();
     $fields = $sqlFields->getArray('SELECT `title`, `name` FROM '.rex::getTable('metainfo_field').' WHERE `name` LIKE :prefix ORDER BY priority', ['prefix' => 'clang_%']);
 
-    if (!count($fields)) {
+    if (0 === count($fields)) {
         return null;
     }
 
+    /** @var rex_clang $clang */
     $clang = $ep->getParam('clang');
     $items = [];
     foreach ($fields as $field) {

--- a/fragments/core/bottom.php
+++ b/fragments/core/bottom.php
@@ -1,9 +1,22 @@
 </div><!-- END .rex-page -->
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * replace the core-fragment bottom.php to add the minibar output before the
+ * closing body-tag.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Minibar;
 
- if (rex_be_controller::getCurrentPage() != 'login' && !rex_be_controller::getCurrentPageObject()->isPopup()): ?>
+$page = rex_be_controller::getCurrentPageObject();
+if (null !== $page && $page->getFullKey() !== 'login' && !$page->isPopup()): ?>
     <button type="button" class="navbar-toggle rex-js-nav-main-toggle" data-toggle="collapse" data-target=".rex-nav-main > .navbar-collapse">
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>

--- a/fragments/minibar/backend.php
+++ b/fragments/minibar/backend.php
@@ -1,13 +1,28 @@
 
 <?php
 
-/** rex_fragment $this */
+/**
+ * This file is part of the Minibar package.
+ *
+ * Fragment: provide the basic backend-structure of the minibar and render all
+ * elements. The elements are rendered by calling their render() method via 
+ * sub-fragment.
+ * 
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/** @var rex_fragment $this */
+
+$elements = $this->getVar('elements', []);
 
 ?>
 <div class="rex-minibar rex-minibar-backend">
     <div class="rex-minibar-elements">
         <?php
-        foreach ($this->elements as $element) {
+        foreach ($elements as $element) {
             $this->subfragment('minibar/element.php', [
                 'element' => $element,
             ]);

--- a/fragments/minibar/element.php
+++ b/fragments/minibar/element.php
@@ -1,15 +1,30 @@
 <?php
-/** @var AbstractElement $element */
+
+/**
+ * This file is part of the Minibar package.
+ *
+ * Fragment for rendering a single element in the minibar. The element is rendered
+ * by calling its render() method. If the element is an instance of AbstractLazyElement,
+ * the content will be loaded on mouseover via AJAX.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 use FriendsOfRedaxo\Minibar\Api\LazyLoader;
 use FriendsOfRedaxo\Minibar\Element\AbstractElement;
 use FriendsOfRedaxo\Minibar\Element\AbstractLazyElement;
 
-$element = $this->element;
+/** @var rex_fragment $this */
+
+/** @var AbstractElement $element */
+$element = $this->getVar('element');
 
 $class = 'rex-minibar-element ';
 $class .= $element->cssClass();
-$class .= (AbstractElement::RIGHT == $element->getOrientation() ? ' rex-minibar-element-right' : '');
+$class .= (AbstractElement::RIGHT === $element->getOrientation() ? ' rex-minibar-element-right' : '');
 $class .= ($element->isDanger() ? ' rex-minibar-status-danger' : '');
 $class .= ($element->isWarning() ? ' rex-minibar-status-warning' : '');
 $class .= ($element->isPrimary() ? ' rex-minibar-status-primary' : '');

--- a/fragments/minibar/frontend.php
+++ b/fragments/minibar/frontend.php
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Fragment: provide the basic frontend-structure of the minibar and render all
+ * elements. The elements are rendered by calling their render() method via
+ * sub-fragment.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Api\LazyLoader;
 use FriendsOfRedaxo\Minibar\Minibar;
 

--- a/lib/Api/ClearCache.php
+++ b/lib/Api/ClearCache.php
@@ -15,6 +15,7 @@
 namespace FriendsOfRedaxo\Minibar\Api;
 
 use rex_api_function;
+use rex_api_result;
 use rex_response;
 
 class ClearCache extends rex_api_function
@@ -22,6 +23,12 @@ class ClearCache extends rex_api_function
     // Nur im Backend
     protected $published = false;
 
+    /**
+     * Löscht den kompletten Cache und sendet eine 200 OK Antwort zurück.
+     * 
+     * @api
+     * @return never
+     */
     public function execute()
     {
         rex_delete_cache();

--- a/lib/Api/LazyLoader.php
+++ b/lib/Api/LazyLoader.php
@@ -18,16 +18,25 @@ use FriendsOfRedaxo\Minibar\Minibar;
 use rex;
 use rex_api_function;
 use rex_fragment;
+use rex_request;
 use rex_response;
 use rex_url;
 
 class LazyLoader extends rex_api_function
 {
+    // Backend and Frontend
     protected $published = true;
 
+    /**
+     * API-Anfgare ausführen. Es werden entweder die Sichtbarkeit der Minibar
+     * gesetzt oder Inhalte von Lazy-Elementen geladen.
+     * 
+     * @api
+     * @return never
+     */
     public function execute()
     {
-        $visibility = rex_get('visibility', 'bool', null);
+        $visibility = rex_request::get('visibility', 'bool', null);
         if (null !== $visibility) {
             Minibar::getInstance()->setVisibility($visibility);
 
@@ -38,11 +47,11 @@ class LazyLoader extends rex_api_function
             rex_response::sendRedirect(rex_getUrl('', '', [], '&'));
         }
 
-        $lazyElement = rex_get('lazy_element', 'string');
-        if ($lazyElement) {
+        $lazyElement = rex_request::get('lazy_element', 'string');
+        if ('' < $lazyElement) {
             $minibar = Minibar::getInstance();
             $element = $minibar->elementByClass($lazyElement);
-            if ($element) {
+            if (null !==$element) {
                 $fragment = new rex_fragment([
                     'element' => $element,
                 ]);
@@ -51,8 +60,16 @@ class LazyLoader extends rex_api_function
                 exit;
             }
         }
+        rex_response::setStatus(rex_response::HTTP_BAD_REQUEST);
+        rex_response::sendContent('Invalid request');
+        exit;
     }
 
+    /**
+     * CSFR-Protection aktivieren
+     * 
+     * @return bool 
+     */
     protected function requiresCsrfProtection()
     {
         return true;

--- a/lib/Element/AbstractElement.php
+++ b/lib/Element/AbstractElement.php
@@ -20,12 +20,15 @@ use rex_string;
 
 abstract class AbstractElement
 {
+    /** @api */
     public const LEFT = 'LEFT';
+    /** @api */
     public const RIGHT = 'RIGHT';
 
     /**
      * Returns the html bar item.
      *
+     * @api
      * @return string
      */
     abstract public function render();
@@ -63,7 +66,11 @@ abstract class AbstractElement
 
     /**
      * Returns the orientation in the minibar.
+     * 
+     * If you want to have a right aligned element, override this method in your
+     * element class and return `self::RIGHT` or rex_minibar_element::RIGHT.
      *
+     * @api
      * @return string `rex_minibar_element::LEFT` or `rex_minibar_element::RIGHT`
      */
     public function getOrientation()
@@ -74,6 +81,7 @@ abstract class AbstractElement
     /**
      * Returns the danger status.
      *
+     * @api
      * @return bool
      */
     public function isDanger()
@@ -84,6 +92,7 @@ abstract class AbstractElement
     /**
      * Returns the primary status.
      *
+     * @api
      * @return bool
      */
     public function isPrimary()
@@ -94,6 +103,7 @@ abstract class AbstractElement
     /**
      * Returns the warning status.
      *
+     * @api
      * @return bool
      */
     public function isWarning()

--- a/lib/Element/AbstractLazyElement.php
+++ b/lib/Element/AbstractLazyElement.php
@@ -21,6 +21,18 @@ use rex_api_function;
 
 abstract class AbstractLazyElement extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     * Either the initial/light-weight html or the full html, 
+     * depending on the context of the call.
+     * 
+     * avoid to overwrite this method in your element class, overwrite either 
+     * renderFirstView() or renderComplete() to apply lazy loading functionality.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         if (self::isFirstView()) {
@@ -29,6 +41,12 @@ abstract class AbstractLazyElement extends AbstractElement
         return $this->renderComplete();
     }
 
+    /**
+     * Check the presentation status (firstViwe or not)
+     *
+     * @api
+     * @return bool
+     */
     public static function isFirstView()
     {
         $apiFn = rex_api_function::factory();
@@ -38,6 +56,7 @@ abstract class AbstractLazyElement extends AbstractElement
     /**
      * Returns the initial/light-weight html representation of this element.
      *
+     * @api
      * @return string
      */
     abstract protected function renderFirstView();
@@ -46,6 +65,7 @@ abstract class AbstractLazyElement extends AbstractElement
      * Returns the full html for this element.
      * This method will be called asynchronously after user starts interacting with the initial element.
      *
+     * @api
      * @return string
      */
     abstract protected function renderComplete();

--- a/lib/Element/AbstractLazyElement.php
+++ b/lib/Element/AbstractLazyElement.php
@@ -42,7 +42,7 @@ abstract class AbstractLazyElement extends AbstractElement
     }
 
     /**
-     * Check the presentation status (firstViwe or not)
+     * Check the presentation status (firstView or not)
      *
      * @api
      * @return bool

--- a/lib/Element/Debug.php
+++ b/lib/Element/Debug.php
@@ -23,6 +23,13 @@ use rex_i18n;
 
 class Debug extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         $links = '';
@@ -108,8 +115,14 @@ class Debug extends AbstractElement
         ';
     }
 
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'right'
+     */
     public function getOrientation()
     {
-        return self::RIGHT;
+        return self::RIGHT; 
     }
 }

--- a/lib/Element/Scheme.php
+++ b/lib/Element/Scheme.php
@@ -26,6 +26,13 @@ use rex_i18n;
 
 class Scheme extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         return '<div class="rex-minibar-item">
@@ -54,6 +61,12 @@ class Scheme extends AbstractElement
             </div>';
     }
 
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'right'
+     */
     public function getOrientation()
     {
         return self::RIGHT;

--- a/lib/Element/StructureArticle.php
+++ b/lib/Element/StructureArticle.php
@@ -29,6 +29,13 @@ use rex_url;
 
 class StructureArticle extends AbstractLazyElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         // create the backend user session, in case it is missing (e.g. in frontend).
@@ -38,6 +45,12 @@ class StructureArticle extends AbstractLazyElement
         return parent::render();
     }
 
+    /**
+     * Returns the initial/light-weight html representation of this element.
+     *
+     * @api
+     * @return string
+     */
     protected function renderFirstView()
     {
         $article = $this->getArticle();
@@ -62,6 +75,13 @@ class StructureArticle extends AbstractLazyElement
         </div>';
     }
 
+    /**
+     * Returns the full html for this element.
+     * This method will be called asynchronously after user starts interacting with the initial element.
+     *
+     * @api
+     * @return string
+     */
     protected function renderComplete()
     {
         $articleId = rex_get('article_id');
@@ -86,7 +106,7 @@ class StructureArticle extends AbstractLazyElement
 
         $articlePath = [];
         $tree = $article->getParentTree();
-        if (!$article->isStartarticle()) {
+        if (!$article->isStartArticle()) {
             $tree[] = $article;
         }
         foreach ($tree as $parent) {
@@ -138,6 +158,14 @@ class StructureArticle extends AbstractLazyElement
         ';
     }
 
+    /**
+     * Helper: detect rex_article in scope and return it´s object.
+     * Fallback: current article
+     * Fallback: start article.
+     *
+     * @api
+     * @return ?rex_article
+     */
     private function getArticle()
     {
         $clangId = rex_request('clang', 'int');
@@ -146,14 +174,14 @@ class StructureArticle extends AbstractLazyElement
         if (rex::isBackend()) {
             $article = rex_article::get(rex_request('article_id', 'int'), $clangId);
 
-            if (!$article) {
+            if (null === $article) {
                 $article = rex_article::get(rex_request('category_id', 'int'), $clangId);
             }
         } else {
             $article = rex_article::getCurrent();
         }
 
-        if (!$article) {
+        if (null === $article) {
             $article = rex_article::getSiteStartArticle();
         }
 

--- a/lib/Element/Syslog.php
+++ b/lib/Element/Syslog.php
@@ -28,6 +28,13 @@ use rex_url;
 
 class Syslog extends AbstractElement
 {
+
+/**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         // create the backend user session, in case it is missing (e.g. in frontend).
@@ -35,7 +42,7 @@ class Syslog extends AbstractElement
 
         // Nur Admins können das Systemlog-Widget sehen
         $user = rex_backend_login::createUser();
-        if (!$user || !$user->isAdmin()) {
+        if (null === $user || !$user->isAdmin()) {
             return '';
         }
 
@@ -49,7 +56,7 @@ class Syslog extends AbstractElement
         $lastModified = filemtime($sysLogFile);
 
         // "last-seen" will be updated, when the user looks into the syslog
-        if (rex::isBackend() && 'system/log/redaxo' == rex_be_controller::getCurrentPage()) {
+        if (rex::isBackend() && 'system/log/redaxo' === rex_be_controller::getCurrentPage()) {
             // use the backend-session instead of rex_session() to make it work consistently across frontend/backend.
             // the frontend should reflect when we look into the log in the backend.
             $login->setSessionVar('rex_syslog_last_seen', $lastModified);
@@ -60,7 +67,7 @@ class Syslog extends AbstractElement
 
         // when the user never looked into the file (e.g. after login), we dont have a timely reference point.
         // therefore we check for changes in the file within the last 24hours
-        if (!$lastSeen) {
+        if (!isset($lastSeen)) {
             if ($lastModified > strtotime('-24 hours')) {
                 $status = 'rex-syslog-changed';
             }
@@ -85,7 +92,7 @@ class Syslog extends AbstractElement
         $url = $editor->getUrl($logFile, 1);
 
         $info = '';
-        if ($url) {
+        if (null !== $url) {
             $info =
                 '<div class="rex-minibar-info">
                     <div class="rex-minibar-info-group">
@@ -99,6 +106,12 @@ class Syslog extends AbstractElement
         return $item . $info;
     }
 
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'right'
+     */
     public function getOrientation()
     {
         return self::RIGHT;

--- a/lib/Element/System.php
+++ b/lib/Element/System.php
@@ -31,17 +31,24 @@ use const PHP_VERSION;
 
 class System extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         $database = rex::getProperty('db');
 
         $links = '';
-        if (rex::getUser() && rex::getUser()->isAdmin()) {
+        if (null !==rex::getUser() && rex::getUser()->isAdmin()) {
             $links .= '<a href="https://redaxo.org/doku/master" target="_blank" rel="help noreferrer noopener">' . rex_i18n::msg('minibar_documentation_link_label') . '</a>';
         }
 
         $clearCache = '';
-        if (rex::getUser() && rex::getUser()->isAdmin() && rex::isDebugMode()) {
+        if (null !== rex::getUser() && rex::getUser()->isAdmin() && rex::isDebugMode()) {
             $clearCache = sprintf(
                 '<br><a href="javascript:(fetch(\'%s\'))">%s</a>',
                 rex_url::currentBackendPage(ClearCache::getUrlParams(), false),
@@ -64,11 +71,11 @@ class System extends AbstractElement
             <div class="rex-minibar-info-group">
                 <div class="rex-minibar-info-piece">
                     <span class="title">REDAXO</span>
-                    <span>' . rex::getVersion() . ' ' . (rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="' . rex_escape(rex_i18n::msg('logfiles')) . '">' . rex_i18n::msg('logfiles') . '</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="' . rex_escape(rex_i18n::msg('system_report')) . '">' . rex_i18n::msg('system_report') . '</a>' . $clearCache : '') . '</span>
+                    <span>' . rex::getVersion() . ' ' . (null !== rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="' . rex_escape(rex_i18n::msg('logfiles')) . '">' . rex_i18n::msg('logfiles') . '</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="' . rex_escape(rex_i18n::msg('system_report')) . '">' . rex_i18n::msg('system_report') . '</a>' . $clearCache : '') . '</span>
                 </div>
                 <div class="rex-minibar-info-piece">
                     <span class="title">PHP Version</span>
-                    <span>' . PHP_VERSION . ' ' . (rex::isBackend() && rex::getUser() && rex::getUser()->isAdmin() ? '<a href="' . rex_url::backendPage('system/phpinfo') . '" title="phpinfo" onclick="newWindow(\'phpinfo\', this.href, 1000,800,\',status=yes,resizable=yes\');return false;">phpinfo()</a>' : '') . '</span>
+                    <span>' . PHP_VERSION . ' ' . (rex::isBackend() && null !== rex::getUser() && rex::getUser()->isAdmin() ? '<a href="' . rex_url::backendPage('system/phpinfo') . '" title="phpinfo" onclick="newWindow(\'phpinfo\', this.href, 1000,800,\',status=yes,resizable=yes\');return false;">phpinfo()</a>' : '') . '</span>
                 </div>
                 <div class="rex-minibar-info-piece">
                     <span class="title">MySQL</span>
@@ -97,7 +104,7 @@ class System extends AbstractElement
                     <span>
                         <a href="https://redaxo.org" target="_blank" rel="help noreferrer noopener">redaxo.org</a>
                         / 
-                        <a href="' . (rex::getUser() ? rex_url::backendPage('credits') : 'https://www.redaxo.org/" target="_blank" rel="noreferrer noopener') . '">' . rex_i18n::msg('footer_credits') . '</a>
+                        <a href="' . (null !== rex::getUser() ? rex_url::backendPage('credits') : 'https://www.redaxo.org/" target="_blank" rel="noreferrer noopener') . '">' . rex_i18n::msg('footer_credits') . '</a>
                         <br />
                         <a href="https://www.yakamara.de" target="_blank" rel="help noreferrer noopener">yakamara.de</a>
                     </span>
@@ -106,11 +113,23 @@ class System extends AbstractElement
         </div>';
     }
 
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'right'
+     */
     public function getOrientation()
     {
         return self::RIGHT;
     }
 
+    /**
+     * Returns the primary status.
+     *
+     * @api
+     * @return bool
+     */
     public function isPrimary()
     {
         return true;

--- a/lib/Element/Time.php
+++ b/lib/Element/Time.php
@@ -24,6 +24,13 @@ use rex_timer;
 
 class Time extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         return
@@ -34,7 +41,13 @@ class Time extends AbstractElement
         </div>';
     }
 
-    public function getOrientation()
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'right'
+     */
+    public function getOrientation(): string
     {
         return self::RIGHT;
     }

--- a/lib/Element/Url2Yform.php
+++ b/lib/Element/Url2Yform.php
@@ -23,8 +23,10 @@ use Exception;
 use rex;
 use rex_addon;
 use rex_backend_login;
+use rex_complex_perm;
 use rex_csrf_token;
 use rex_i18n;
+use rex_request;
 use rex_url;
 use rex_yform_manager_table;
 use Url\Url;
@@ -33,6 +35,13 @@ use function call_user_func;
 
 class Url2Yform extends AbstractElement
 {
+
+    /**
+     * Returns the html bar item.
+     *
+     * @api
+     * @return string
+     */
     public function render()
     {
         // create the backend user session, in case it is missing (e.g. in frontend).
@@ -43,7 +52,7 @@ class Url2Yform extends AbstractElement
 
         // Check permissions first
         $user = rex_backend_login::createUser();
-        if (!$user) {
+        if (null === $user) {
             return '';
         }
 
@@ -57,7 +66,7 @@ class Url2Yform extends AbstractElement
         $value = rex_i18n::msg('minibar_url2_yform_title');
         $itemStyle = '';
 
-        if ($url2Info && $url2Info['is_yform_table']) {
+        if (is_array($url2Info) && isset($url2Info['is_yform_table']) && $url2Info['is_yform_table']) {
             $status = 'rex-minibar-url2-found';
             $value = $url2Info['table_label'];
             // Noch dunklerer grüner Hintergrund wenn YForm-Daten gefunden
@@ -75,14 +84,14 @@ class Url2Yform extends AbstractElement
             </div>';
 
         $info = '';
-        if ($url2Info && $url2Info['is_yform_table']) {
+        if (is_array($url2Info) && isset($url2Info['is_yform_table']) && $url2Info['is_yform_table']) {
             // Get CSRF token for YForm operations
             $csrf_token = null;
             if (rex::isFrontend() && rex_backend_login::hasSession()) {
                 rex::setProperty('redaxo', true);
                 try {
                     $table = rex_yform_manager_table::get($url2Info['table']);
-                    if ($table) {
+                    if (null !== $table) {
                         $_csrf_key = $table->getCSRFKey();
                         $_csrf_params = rex_csrf_token::factory($_csrf_key)->getUrlParams();
                         $csrf_token = $_csrf_params['_csrf_token'];
@@ -102,7 +111,7 @@ class Url2Yform extends AbstractElement
                     'data_id' => $url2Info['record_id'],
                     'func' => 'edit',
                 ];
-                if ($csrf_token) {
+                if (null !== $csrf_token && '' < $csrf_token) {
                     $recordParams['_csrf_token'] = $csrf_token;
                 }
 
@@ -120,7 +129,7 @@ class Url2Yform extends AbstractElement
             $canEditTable = false;
             $canViewTable = false;
 
-            if ($table && $user) {
+            if (null !== $table) {
                 // Admin kann alles
                 if ($user->isAdmin()) {
                     $canEditTable = true;
@@ -134,7 +143,7 @@ class Url2Yform extends AbstractElement
                     }
 
                     $complexPerm = $user->getComplexPerm('yform_manager_table' . $yperm_suffix);
-                    if ($complexPerm && method_exists($complexPerm, 'hasPerm')) {
+                    if (null !== $complexPerm && method_exists($complexPerm, 'hasPerm')) {
                         $canEditTable = call_user_func([$complexPerm, 'hasPerm'], $url2Info['table']);
                         $canViewTable = $canEditTable;
                     } else {
@@ -187,11 +196,23 @@ class Url2Yform extends AbstractElement
         return $item . $info;
     }
 
+    /**
+     * Returns the orientation in the minibar.
+     *
+     * @api
+     * @return string 'left'
+     */
     public function getOrientation()
     {
         return self::LEFT;
     }
 
+    /**
+     * Helper: retieve URL-information as array
+     * 
+     * @api
+     * @return ?array<string:bool|int|object|string> 
+     */
     private function getUrl2Info(): ?array
     {
         try {
@@ -222,7 +243,7 @@ class Url2Yform extends AbstractElement
 
             // Check if it's a YForm table
             $table = rex_yform_manager_table::get($tableName);
-            if (!$table) {
+            if (null === $table) {
                 return null;
             }
 
@@ -236,7 +257,7 @@ class Url2Yform extends AbstractElement
             $tableLabel = $table->getName() ?: $tableName;
 
             return [
-                'url' => $_SERVER['REQUEST_URI'] ?? '',
+                'url' => rex_request::server('REQUEST_URI', 'string', ''),
                 'is_yform_table' => true,
                 'table' => $tableName,
                 'table_label' => $tableLabel, // Use human-readable table description from name field

--- a/lib/Minibar.php
+++ b/lib/Minibar.php
@@ -32,10 +32,10 @@ class Minibar
     /** @var bool|null */
     private $isActive;
 
-    /** @var array<rex_minibar_element> */
+    /** @var array<AbstractElement> */
     private $elements = [];
 
-    public function addElement(AbstractElement $instance)
+    public function addElement(AbstractElement $instance): void
     {
         $this->elements[] = $instance;
     }
@@ -47,7 +47,7 @@ class Minibar
      *
      * @param string $className
      *
-     * @return rex_minibar_element|null
+     * @return AbstractElement|null
      */
     public function elementByClass($className)
     {
@@ -65,7 +65,7 @@ class Minibar
             return null;
         }
 
-        if (!count($this->elements)) {
+        if (0 === count($this->elements)) {
             return null;
         }
 
@@ -92,7 +92,7 @@ class Minibar
         }
 
         $user = rex_backend_login::createUser();
-        if (!$user) {
+        if (null === $user) {
             return false;
         }
 

--- a/lib/Settings/HideEmptyMetainfos.php
+++ b/lib/Settings/HideEmptyMetainfos.php
@@ -23,14 +23,27 @@ use rex_system_setting;
 
 class HideEmptyMetainfos extends rex_system_setting
 {
+    
+    /** @api */
     public const SHOW = 1;
+    /** @api */
     public const HIDE = -1;
 
+    /**
+     * Returns the key for this system setting.
+     *
+     * @return string
+     */
     public function getKey()
     {
         return 'minibar_hide_empty_metainfos';
     }
 
+    /**
+     * Returns the form field for this system setting.
+     *
+     * @return rex_form_select_element
+     */
     public function getField()
     {
         $field = new rex_form_select_element();
@@ -43,6 +56,12 @@ class HideEmptyMetainfos extends rex_system_setting
         return $field;
     }
 
+    /**
+     * Write the value for this field to the config-table.
+     *
+     * @param mixed $value
+     * @return bool
+     */
     public function setValue($value)
     {
         $value = (int) $value;

--- a/lib/Settings/MinibarInPopup.php
+++ b/lib/Settings/MinibarInPopup.php
@@ -21,14 +21,27 @@ use rex_system_setting;
 
 class MinibarInPopup extends rex_system_setting
 {
+
+    /** @api */
     public const ENABLED = 1;
+    /** @api */
     public const DISABLED = -1;
 
+    /**
+     * Returns the key for this system setting.
+     *
+     * @return string
+     */
     public function getKey()
     {
         return 'minibar_inpopup_enabled';
     }
 
+    /**
+     * Returns the form field for this system setting.
+     *
+     * @return rex_form_select_element
+     */
     public function getField()
     {
         $field = new rex_form_select_element();
@@ -41,10 +54,21 @@ class MinibarInPopup extends rex_system_setting
         return $field;
     }
 
+    /**
+     * Write the value for this field to the config-table.
+     *
+     * @param mixed $value
+     * @return bool
+     */
     public function setValue($value)
     {
         $value = (int) $value;
         rex_config::set('minibar', 'inpopup_enabled', $value);
         return true;
+    }
+
+    public static function isEnabled()
+    {
+        return self::ENABLED === rex_config::get('minibar', 'inpopup_enabled', self::DISABLED);
     }
 }

--- a/lib/Settings/Scope.php
+++ b/lib/Settings/Scope.php
@@ -26,16 +26,31 @@ use rex_system_setting;
 
 class Scope extends rex_system_setting
 {
+    
+    /** @api */
     public const DISABLED = -1;
+    /** @api */
     public const ENABLED_EVERYWHERE = 1;
+    /** @api */
     public const ENABLED_FRONTEND = 2;
+    /** @api */
     public const ENABLED_BACKEND = 3;
 
+    /**
+     * Returns the key for this system setting.
+     *
+     * @return string
+     */
     public function getKey()
     {
         return 'minibar_enabled';
     }
 
+    /**
+     * Returns the form field for this system setting.
+     *
+     * @return rex_form_select_element
+     */
     public function getField()
     {
         $field = new rex_form_select_element();
@@ -50,6 +65,12 @@ class Scope extends rex_system_setting
         return $field;
     }
 
+    /**
+     * Write the value for this field to the config-table.
+     *
+     * @param mixed $value
+     * @return bool
+     */
     public function setValue($value)
     {
         $value = (int) $value;

--- a/lib/deprecated/api_minibar.php
+++ b/lib/deprecated/api_minibar.php
@@ -1,8 +1,23 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * API class for lazy loading content of elements which are a subclass to
+ * "FriendsOfRedaxo\Minibar\Element\AbstractLazyElement"
+ * 
+ * Shim-Class to access the API via `rex_api_minibar` for backward compatibility.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Api\LazyLoader;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Api\LazyLoader` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Api\LazyLoader` instead
  */
 class rex_api_minibar extends LazyLoader {}

--- a/lib/deprecated/article.php
+++ b/lib/deprecated/article.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_structure_article`
+ * for backward compatibility to `StructureArticle`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\StructureArticle;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\StructureArticle` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\StructureArticle` instead
  */
 class rex_minibar_element_structure_article extends StructureArticle {}

--- a/lib/deprecated/debug.php
+++ b/lib/deprecated/debug.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_debug`
+ * for backward compatibility to `Debug`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\Debug;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\Debug` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\Debug` instead
  */
 class rex_minibar_element_debug extends Debug {}

--- a/lib/deprecated/element.php
+++ b/lib/deprecated/element.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element`
+ * for backward compatibility to `AbstractElement`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\AbstractElement;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\AbstractElement` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\AbstractElement` instead
  */
 abstract class rex_minibar_element extends AbstractElement {}

--- a/lib/deprecated/lazy.php
+++ b/lib/deprecated/lazy.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_lazy_element`
+ * for backward compatibility to `AbstractLazyElement`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\AbstractLazyElement;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\AbstractLazyElement` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\AbstractLazyElement` instead
  */
 abstract class rex_minibar_lazy_element extends AbstractLazyElement {}

--- a/lib/deprecated/minibar.php
+++ b/lib/deprecated/minibar.php
@@ -1,8 +1,20 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the class `rex_minibar` for backward compatibility to `Minibar`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Minibar;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Minibar` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Minibar` instead
  */
 class rex_minibar extends Minibar {}

--- a/lib/deprecated/scheme.php
+++ b/lib/deprecated/scheme.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_scheme`
+ * for backward compatibility to `Scheme`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\Scheme;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\Scheme` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\Scheme` instead
  */
 class rex_minibar_element_scheme extends Scheme {}

--- a/lib/deprecated/syslog.php
+++ b/lib/deprecated/syslog.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_syslog`
+ * for backward compatibility to `Syslog`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\Syslog;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\Syslog` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\Syslog` instead
  */
 class rex_minibar_element_syslog extends Syslog {}

--- a/lib/deprecated/system.php
+++ b/lib/deprecated/system.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_system`
+ * for backward compatibility to `System`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\System;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\System` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\System` instead
  */
 class rex_minibar_element_system extends System {}

--- a/lib/deprecated/system_setting_hide_empty_metainfos.php
+++ b/lib/deprecated/system_setting_hide_empty_metainfos.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the settings-class `rex_system_setting_minibar_hide_empty_metainfos`
+ * for backward compatibility to `HideEmptyMetainfos`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Settings\HideEmptyMetainfos;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Settings\HideEmptyMetainfos` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Settings\HideEmptyMetainfos` instead
  */
 class rex_system_setting_minibar_hide_empty_metainfos extends HideEmptyMetainfos {}

--- a/lib/deprecated/system_setting_minibar.php
+++ b/lib/deprecated/system_setting_minibar.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the settings-class `rex_system_setting_minibar_inpopup`
+ * for backward compatibility to `InPopup`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Settings\MinibarInPopup;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Settings\MinibarInPopup` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Settings\MinibarInPopup` instead
  */
 class rex_system_setting_minibar_inpopup extends MinibarInPopup {}

--- a/lib/deprecated/system_setting_minibar_inpopup.php
+++ b/lib/deprecated/system_setting_minibar_inpopup.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the settings-class `rex_system_setting_minibar`
+ * for backward compatibility to `Scope`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Settings\Scope;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Settings\Scope` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Settings\Scope` instead
  */
 class rex_system_setting_minibar extends Scope {}

--- a/lib/deprecated/time.php
+++ b/lib/deprecated/time.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_time`
+ * for backward compatibility to `Time`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\Time;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\Time` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\Time` instead
  */
 class rex_minibar_element_time extends Time {}

--- a/lib/deprecated/url2_yform.php
+++ b/lib/deprecated/url2_yform.php
@@ -1,8 +1,21 @@
 <?php
 
+/**
+ * This file is part of the Minibar package.
+ *
+ * Shim-Class to access the element-class `rex_minibar_element_url2_yform`
+ * for backward compatibility to `Url2Yform`.
+ * This class is marked as deprecated and will be removed in Minibar 4.0.0.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use FriendsOfRedaxo\Minibar\Element\Url2Yform;
 
 /**
- * @deprecated Use namespaced class `FriendsOfRedaxo\Minibar\Element\Url2Yform` instead
+ * @deprecated 3.0.0 Use namespaced class `FriendsOfRedaxo\Minibar\Element\Url2Yform` instead
  */
 class rex_minibar_element_url2_yform extends Url2Yform {}


### PR DESCRIPTION
Code-Analyse mit Rexstan und Behebung der gemeldeten Kritikpunkte.

Zusätzliche Kommentare; Z.B. von Rexstan als nicht genutzt eingestufte Public-Methoden werden mit `@api` markiert. Zusätzlich werden _alle_ public-Methoden und Werte mit `@api` markiert.

Weiterhin sind die meisten Methoden via PHPDOCS beschrieben; z.B. die Return-Typen. Dies ließe sich komplett durch PHP-Code ersetzen, allerdings ist dann die Rückwärtskompatibilität über die Shim-Klasen nicht mehr gegeben. Richtig konsequent wäre der harte Umstieg:
- keine Shim-Klassen und damit keinerlei Rückwärtskompatibilität
- PHPDOCS auflösen in PHP-Code woimmer möglich
- auch  CSS-Namen angleichen

Wenn keiner Einwände hat, merge ich den PR am Nachmittag/abend. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Verbesserte Lazy-Loading-Funktionalität für AJAX-basierte Elementdarstellung.
  * Feiner gesteuerte Minibar-Aktivierung für Popups.

* **Bug Fixes**
  * Erhöhte Stabilität durch strengere Typ- und Null-Prüfungen.
  * Korrigierte Datums- und Uhrzeitformatierung in Elementen.

* **Documentation**
  * Umfangreiche API-Dokumentation für öffentliche Klassen und Methoden.
  * Veraltete Shims mit Versionsangaben markiert (Entfernung in v4.0.0 geplant).

* **Chores**
  * Performance- und Konsistenzverbesserungen beim Rendering und Laden von Elementen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->