### PR TITLE
überflüssiges rex_escape entfernt

### DIFF
--- a/lib/Element/System.php
+++ b/lib/Element/System.php
@@ -52,7 +52,7 @@ class System extends AbstractElement
             $clearCache = sprintf(
                 '<br><a href="javascript:(fetch(\'%s\'))">%s</a>',
                 rex_url::currentBackendPage(ClearCache::getUrlParams(), false),
-                rex_escape(rex_i18n::msg('delete_cache')),
+                rex_i18n::msg('delete_cache'),
             );
         }
 
@@ -71,7 +71,7 @@ class System extends AbstractElement
             <div class="rex-minibar-info-group">
                 <div class="rex-minibar-info-piece">
                     <span class="title">REDAXO</span>
-                    <span>' . rex::getVersion() . ' ' . (null !== rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="' . rex_escape(rex_i18n::msg('logfiles')) . '">' . rex_i18n::msg('logfiles') . '</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="' . rex_escape(rex_i18n::msg('system_report')) . '">' . rex_i18n::msg('system_report') . '</a>' . $clearCache : '') . '</span>
+                    <span>' . rex::getVersion() . ' ' . (null !== rex::getUser() && rex::getUser()->isAdmin() ? '<br><a href="' . rex_url::backendPage('system/log') . '" title="' . rex_i18n::msg('logfiles') . '">' . rex_i18n::msg('logfiles') . '</a> <br><a href="' . rex_url::backendPage('system/report') . '" title="' . rex_i18n::msg('system_report') . '">' . rex_i18n::msg('system_report') . '</a>' . $clearCache : '') . '</span>
                 </div>
                 <div class="rex-minibar-info-piece">
                     <span class="title">PHP Version</span>


### PR DESCRIPTION
Überflüssiges `rex_escape` entfernt. Die Kombination `rex_escape(rex_i18n::msg(..))` führt ein doppeltes Escape durch. Beispiel:

- .lang-Text: "xyz\&dash;z"
- nach 'rex_i18n::msg(..)`: "xyz\&amp;dash;z"
- nach `rex_escape(rex_i18n::msg(..))`: "xyz\&amp;amp;dash;z"

Es fiel bisher nicht auf, da die Texte keine Zeichen enthalten, die escaped werden müssen.

closes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Verbesserungen**
  * Admin-Benutzer können jetzt zusätzliche Links zu Systemprotokoll und Berichten in der Systemanzeige aufrufen.
  * Cache-Lösch-Beschriftung wurde angepasst und wird nun konsistent angezeigt.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriendsOfREDAXO/minibar/pull/111)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->