### PR TITLE
Debug-Element überarbeitet

### DIFF
--- a/fragments/minibar/debug.php
+++ b/fragments/minibar/debug.php
@@ -16,16 +16,16 @@
 
 $adminLinks = '';
 
-if( $this->getVar('adminLinks', false) ) {
+if ($this->getVar('adminLinks', false)) {
     $adminLinks .= sprintf(
         '<span><a href="%s">%s</a></span><br>',
         rex_url::backendPage('system'),
-        rex_i18n::msg('minibar_debug_system_settings')
+        rex_i18n::msg('minibar_debug_system_settings'),
     );
     if ($this->getVar('debugLink', false)) {
         $adminLinks .= sprintf('<span><a href="%s" target="_blank">%s</a></span>',
             rex_url::backendPage('debug'),
-            rex_i18n::msg('minibar_debug_start_debug')
+            rex_i18n::msg('minibar_debug_start_debug'),
         );
     }
         $adminLinks = sprintf(

--- a/fragments/minibar/debug.php
+++ b/fragments/minibar/debug.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of the Minibar package.
+ *
+ * Fragment for rendering the debug element in the minibar. The element is rendered
+ * by calling its render() method.
+ *
+ * @author (c) Friends Of REDAXO
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/** @var rex_fragment $this */
+
+$adminLinks = '';
+
+if( $this->getVar('adminLinks', false) ) {
+    $adminLinks .= sprintf(
+        '<span><a href="%s">%s</a></span><br>',
+        rex_url::backendPage('system'),
+        rex_i18n::msg('minibar_debug_system_settings')
+    );
+    if ($this->getVar('debugLink', false)) {
+        $adminLinks .= sprintf('<span><a href="%s" target="_blank">%s</a></span>',
+            rex_url::backendPage('debug'),
+            rex_i18n::msg('minibar_debug_start_debug')
+        );
+    }
+        $adminLinks = sprintf(
+            '<div class="rex-minibar-info-piece"><span class="title">%s</span>%s</div>',
+            rex_i18n::msg('minibar_debug_links'),
+            $adminLinks,
+        );
+}
+
+?>
+<style>
+
+.rex-minibar-debug {
+    animation:rex-pulse 5s ease infinite;
+	color: #f09000;
+}
+
+@keyframes rex-pulse {
+    0% {
+        transform:scale(1)
+    }
+
+    5% {
+        transform:scale(1.15)
+    }
+
+    20% {
+        transform:scale(1)
+    }
+
+    30% {
+        transform:scale(1)
+    }
+
+    35% {
+        transform:scale(1.15)
+    }
+
+    50% {
+        transform:scale(1)
+    }
+
+    55% {
+        transform:scale(1.25)
+    }
+
+    70% {
+        transform:scale(1)
+    }
+}
+
+</style>
+<div class="rex-minibar-item">
+    <span class="rex-minibar-icon">
+        <i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i> 
+    </span>
+    <span class="rex-minibar-value">
+        <?= rex_i18n::msg('debug_mode') ?>
+    </span>
+</div>
+<div class="rex-minibar-info">
+    <div class="rex-minibar-info-header">
+        <i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i>
+        <?= rex_i18n::msg('minibar_debug_header')?>
+    </div>
+    <div class="rex-minibar-info-group">
+        <div class="rex-minibar-info-piece">
+            <span class="title"><?= rex_i18n::msg('minibar_debug_info') ?></span>
+            <span>
+                <?= rex_i18n::msg('minibar_debug_info_text') ?>
+            </span>
+        </div>
+        <?= $adminLinks ?>
+    </div>
+</div>

--- a/lib/Element/Debug.php
+++ b/lib/Element/Debug.php
@@ -19,7 +19,9 @@ namespace FriendsOfRedaxo\Minibar\Element;
 
 use rex;
 use rex_addon;
+use rex_fragment;
 use rex_i18n;
+use rex_url;
 
 class Debug extends AbstractElement
 {
@@ -32,87 +34,13 @@ class Debug extends AbstractElement
      */
     public function render()
     {
-        $links = '';
-        if (rex::getUser()->isAdmin()) {
-            $links = '	    
-                <div class="rex-minibar-info-piece">
-                    <span class="title">' . rex_i18n::msg('minibar_debug_links') . '</span>
-                    <span>
-                        <a href="/redaxo/index.php?page=system">' . rex_i18n::msg('minibar_debug_system_settings') . '</a>
-                    </span>
-                    <br>';
-            if (rex_addon::get('debug')->isAvailable()) {
-                $links .= '<span>
-                 <a href="/redaxo/index.php?page=debug" target="_blank">' . rex_i18n::msg('minibar_debug_start_debug') . '</a>
-         </span>
-';
-            }
-
-            $links .= '</div>';
+        $fragment = new rex_fragment();
+        $fragment->setVar('adminLinks', false, false);
+        if (null !== rex::getUser() && rex::getUser()->isAdmin()) {
+            $fragment->setVar('adminLinks', true, false);
+            $fragment->setVar('debugLink', rex_addon::get('debug')->isAvailable(), false);
         }
-        return
-        '
-        <style>
-        .rex-minibar-debug {
-    animation:rex-pulse 5s ease infinite;
-	color: #f09000;
-}
-@keyframes rex-pulse {
-    0% {
-        transform:scale(1)
-    }
-
-    5% {
-        transform:scale(1.15)
-    }
-
-    20% {
-        transform:scale(1)
-    }
-
-    30% {
-        transform:scale(1)
-    }
-
-    35% {
-        transform:scale(1.15)
-    }
-
-    50% {
-        transform:scale(1)
-    }
-
-    55% {
-        transform:scale(1.25)
-    }
-
-    70% {
-        transform:scale(1)
-    }
-}
-
-        </style>
-        <div class="rex-minibar-item">
-            <span class="rex-minibar-icon">
-                <i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i> 
-            </span>
-            <span class="rex-minibar-value">
-            ' . rex_i18n::msg('debug_mode') . '
-            </span>
-        </div>
-<div class="rex-minibar-info">
-        <div class="rex-minibar-info-header"><i class="rex-minibar-debug rex-minibar-icon--fa rex-minibar-icon--fa-heartbeat"></i>  ' . rex_i18n::msg('minibar_debug_header') . '</div>
-            <div class="rex-minibar-info-group">
-                <div class="rex-minibar-info-piece">
-                    <span class="title">' . rex_i18n::msg('minibar_debug_info') . '</span>
-                    <span>
-                        ' . rex_i18n::msg('minibar_debug_info_text') . '
-                    </span>
-                </div>
-             ' . $links . '
-            </div>
-        </div>
-        ';
+        return $fragment->parse('minibar/debug.php');
     }
 
     /**

--- a/lib/Element/Debug.php
+++ b/lib/Element/Debug.php
@@ -20,12 +20,9 @@ namespace FriendsOfRedaxo\Minibar\Element;
 use rex;
 use rex_addon;
 use rex_fragment;
-use rex_i18n;
-use rex_url;
 
 class Debug extends AbstractElement
 {
-
     /**
      * Returns the html bar item.
      *
@@ -51,6 +48,6 @@ class Debug extends AbstractElement
      */
     public function getOrientation()
     {
-        return self::RIGHT; 
+        return self::RIGHT;
     }
 }


### PR DESCRIPTION
Wie in #102 beschrieben hat CodeRabbit im Debug-Element Verbesserungspotential gefunden. Die drei Stellen sind korrigiert:

- 2 x fixe Url durch generoerte Url ersetzt
- `rex::getUser` auf `null` überprüft.

Zusätzlich bei der Gelegenheit alle Passagen zur HTML-Erzeugung in ein Fragment ausgelagert. 


closes #102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Die Implementierung des Debug-Mode-Elements wurde reorganisiert, um eine template-basierte Renderierung zu verwenden. Die Funktionalität bleibt unverändert.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriendsOfREDAXO/minibar/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->